### PR TITLE
Encode strings with `String#inspect`

### DIFF
--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -314,7 +314,7 @@ module Penman
         if p.nil?
           'nil'
         elsif p.is_a? String
-          p.inspect
+          "Base64.decode('#{Base64.encode(p)}')"
         elsif p.is_a? Time
           "Time.parse('#{p}')"
         else

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -314,7 +314,7 @@ module Penman
         if p.nil?
           'nil'
         elsif p.is_a? String
-          "'#{p}'"
+          p.inspect
         elsif p.is_a? Time
           "Time.parse('#{p}')"
         else

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -314,7 +314,7 @@ module Penman
         if p.nil?
           'nil'
         elsif p.is_a? String
-          "Base64.decode('#{Base64.encode(p)}')"
+          p.inspect
         elsif p.is_a? Time
           "Time.parse('#{p}')"
         else

--- a/lib/penman/version.rb
+++ b/lib/penman/version.rb
@@ -1,7 +1,7 @@
 module Penman
   MAJOR = 0     # api
   MINOR = 4     # features
-  PATCH = 9     # bug fixes
+  PATCH = 10    # bug fixes
 
   VERSION = [MAJOR, MINOR, PATCH].compact.join('.')
 end

--- a/spec/dummy/spec/models/record_tag_spec.rb
+++ b/spec/dummy/spec/models/record_tag_spec.rb
@@ -404,7 +404,7 @@ describe Penman::RecordTag do
 
       weapon = Weapon.find_by(reference: "devlin's weapon")
       expect(weapon).not_to be_nil
-      expect(weapon.category).to eq('"\"]''%"')
+      expect(weapon.category).to eq("\"]''%")
     end
 
     it 'should seed a simple model with nil values' do

--- a/spec/dummy/spec/models/record_tag_spec.rb
+++ b/spec/dummy/spec/models/record_tag_spec.rb
@@ -395,6 +395,18 @@ describe Penman::RecordTag do
       expect(weapon.category).to eq('some_category')
     end
 
+    it 'should correctly seed strings with special characters in it' do
+      weapon = Weapon.create(reference: "devlin's weapon", category: "\"]''%")
+      seed_files = Penman::RecordTag.generate_seed_for_model(Weapon)
+      weapon.destroy
+
+      run_seed(seed_files)
+
+      weapon = Weapon.find_by(reference: "devlin's weapon")
+      expect(weapon).not_to be_nil
+      expect(weapon.category).to eq('"\"]''%"')
+    end
+
     it 'should seed a simple model with nil values' do
       weapon = Weapon.create(reference: 'new_weapon', category: 'some_category', damage_factor: nil)
       seed_files = Penman::RecordTag.generate_seed_for_model(Weapon)


### PR DESCRIPTION
This means that strings including apostrophes, quotation marks and other string
delimeters are supported.