### PR TITLE
Allow Rails 5 Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,8 @@
 ### 0.4.10
 - Encode strings with `.inspect`, allowing for special characters in the strings to be escaped.
 - [pull request](https://github.com/uken/penman/pull/10)
+
+### 0.5.10
+- relax rails constraint, allowing rails 5 apps to use the gem
+- direct users to put the configuration in initializers
+- [pull request](https://github.com/uken/penman/pull/11) (thanks @nearlyfreeapps)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    penman (0.3.9)
-      rails (~> 4)
+    penman (0.4.10)
+      rails (>= 4)
 
 GEM
   remote: https://rubygems.org/
@@ -45,6 +45,7 @@ GEM
     arel (6.0.3)
     builder (3.2.2)
     coderay (1.1.0)
+    concurrent-ruby (1.0.1)
     database_cleaner (1.5.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -57,7 +58,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.2)
+    mime-types (2.99.1)
     mini_portile (0.6.2)
     minitest (5.8.1)
     mysql2 (0.3.20)
@@ -115,12 +116,13 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     slop (3.6.0)
-    sprockets (3.4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -137,4 +139,4 @@ DEPENDENCIES
   rspec-rails (~> 3.3, >= 3.3.3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By including the `Taggable` module, Penman will track changes to that module via
 Once satisfied with the changes made, call `Penman.generate_seeds` to produce seed files representing the changes. This method returns an array of seed file names which you can use to zip and download, upload elsewhere, commit directly to your repository, etc.
 
 ## Configuration
-Here is an example config file that you should consider putting in a `config/penman.rb` file if the defaults aren't working for you:
+Here is an example config file that you should consider putting in a `config/initializers/penman.rb` file if the defaults aren't working for you:
 
 ```ruby
 Penman.configure do |config|

--- a/lib/penman/version.rb
+++ b/lib/penman/version.rb
@@ -1,6 +1,6 @@
 module Penman
   MAJOR = 0     # api
-  MINOR = 4     # features
+  MINOR = 5     # features
   PATCH = 10    # bug fixes
 
   VERSION = [MAJOR, MINOR, PATCH].compact.join('.')

--- a/penman.gemspec
+++ b/penman.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '~> 4'
+  s.add_dependency 'rails', '>= 4'
 
   s.add_development_dependency 'mysql2', '~> 0.3', '>= 0.3.18'
   s.add_development_dependency 'rspec-rails', '~> 3.3', '>= 3.3.3'


### PR DESCRIPTION
Just a couple small things while setting up Penman in J!

- Allows Rails 5 Apps
- Note that custom config should live in initializers (took me a while to realize why my config wasn't being used.
- The only other thing I got bit by for a little while was that I was trying to use models that didn't have standard id fields 