### PR TITLE
Update penman to support passing in a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,7 @@
 ### 0.4.10
 - Encode strings with `.inspect`, allowing for special characters in the strings to be escaped.
 - [pull request](https://github.com/uken/penman/pull/10)
+
+### 0.5.10
+- Add functionality for generating seeds only for specific models (thanks @lyrebird!)
+- [pull request](https://github.com/uken/penman/pull/12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    penman (0.3.9)
+    penman (0.4.10)
       rails (~> 4)
 
 GEM
@@ -45,6 +45,7 @@ GEM
     arel (6.0.3)
     builder (3.2.2)
     coderay (1.1.0)
+    concurrent-ruby (1.0.1)
     database_cleaner (1.5.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -57,7 +58,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.2)
+    mime-types (2.99.1)
     mini_portile (0.6.2)
     minitest (5.8.1)
     mysql2 (0.3.20)
@@ -115,12 +116,13 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     slop (3.6.0)
-    sprockets (3.4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -137,4 +139,4 @@ DEPENDENCIES
   rspec-rails (~> 3.3, >= 3.3.3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/penman.rb
+++ b/lib/penman.rb
@@ -36,4 +36,8 @@ module Penman
   def self.generate_seeds
     RecordTag.generate_seeds
   end
+
+  def self.generate_seeds_for_models(models)
+    RecordTag.generate_seeds_for_models(models)
+  end
 end

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -147,7 +147,7 @@ module Penman
           time += 1.second
         end
 
-        RecordTag.where(record_type: models.map(&:name)).destroy_all
+        RecordTag.where(record_type: models.map(&:name)).delete_all
         seed_files.compact
       end
 

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -132,7 +132,7 @@ module Penman
 
       def generate_seeds_for_models(models)
         models = valid_ordered_models_for_seeds(models)
-        return if models.empty?
+        return [] if models.empty?
 
         time = Time.now
         seed_files = []

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -132,6 +132,7 @@ module Penman
 
       def generate_seeds_for_models(models)
         models = valid_ordered_models_for_seeds(models)
+        return if models.empty?
 
         time = Time.now
         seed_files = []

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -146,7 +146,7 @@ module Penman
           time += 1.second
         end
 
-        RecordTag.where(record_type: models_for_seeds.map(&:name)).destroy_all
+        RecordTag.where(record_type: models.map(&:name)).destroy_all
         seed_files.compact
       end
 

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -127,21 +127,21 @@ module Penman
       end
 
       def generate_seeds
-        generate_seeds_for_models(@@taggable_models)
+        generate_seeds_for_models
       end
 
       def generate_seeds_for_models(models)
-        models_for_seeds = valid_ordered_models_for_seeds(models)
+        models = valid_ordered_models_for_seeds(models)
 
         time = Time.now
         seed_files = []
 
-        models_for_seeds.each do |model|
+        models.each do |model|
           seed_files << generate_update_seed(model, time.strftime('%Y%m%d%H%M%S'))
           time += 1.second
         end
 
-        models_for_seeds.reverse.each do |model|
+        models.reverse.each do |model|
           seed_files << generate_destroy_seed(model, time.strftime('%Y%m%d%H%M%S'))
           time += 1.second
         end
@@ -181,7 +181,7 @@ module Penman
         @@roots -= @@tree[model]
       end
 
-      def seed_order(models)
+      def seed_order(models = @@taggable_models)
         reset_tree
         models.each { |m| add_model_to_tree(m) }
 

--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -127,7 +127,7 @@ module Penman
       end
 
       def generate_seeds
-        generate_seeds_for_models
+        generate_seeds_for_models(seed_order)
       end
 
       def generate_seeds_for_models(models)

--- a/lib/penman/version.rb
+++ b/lib/penman/version.rb
@@ -1,6 +1,6 @@
 module Penman
   MAJOR = 0     # api
-  MINOR = 4     # features
+  MINOR = 5     # features
   PATCH = 10    # bug fixes
 
   VERSION = [MAJOR, MINOR, PATCH].compact.join('.')

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    penman (0.3.9)
+    penman (0.4.10)
       rails (~> 4)
 
 GEM
@@ -43,6 +43,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     builder (3.2.2)
+    concurrent-ruby (1.0.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     globalid (0.3.6)
@@ -53,7 +54,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.6.2)
+    mime-types (2.99.1)
     mini_portile (0.6.2)
     minitest (5.8.1)
     mysql2 (0.3.20)
@@ -104,12 +105,13 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    sprockets (3.4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -124,4 +126,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/spec/dummy/app/models/player_info.rb
+++ b/spec/dummy/app/models/player_info.rb
@@ -1,0 +1,5 @@
+class PlayerInfo < ActiveRecord::Base
+  belongs_to :user
+
+  # notice that this doesn't include Taggable.
+end

--- a/spec/dummy/db/migrate/20160324223036_add_player_info_table.rb
+++ b/spec/dummy/db/migrate/20160324223036_add_player_info_table.rb
@@ -1,0 +1,9 @@
+class AddPlayerInfoTable < ActiveRecord::Migration
+  def change
+    create_table :player_infos do |t|
+      t.integer :player_id, null: false
+      t.string :key, null: false
+      t.string :value
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151106140902) do
+ActiveRecord::Schema.define(version: 20160324223036) do
 
   create_table "assets", force: :cascade do |t|
     t.string   "reference",  limit: 255
@@ -56,6 +56,12 @@ ActiveRecord::Schema.define(version: 20151106140902) do
   end
 
   add_index "multi_sets", ["reference"], name: "index_multi_sets_on_reference", unique: true, using: :btree
+
+  create_table "player_infos", force: :cascade do |t|
+    t.integer "player_id", limit: 4,   null: false
+    t.string  "key",       limit: 255, null: false
+    t.string  "value",     limit: 255
+  end
 
   create_table "players", force: :cascade do |t|
     t.string   "name",       limit: 255

--- a/spec/dummy/spec/models/record_tag_spec.rb
+++ b/spec/dummy/spec/models/record_tag_spec.rb
@@ -530,6 +530,12 @@ describe Penman::RecordTag do
     end
   end
 
+  describe '.generate_seeds_for_models' do
+    it 'should only generate seeds for the models that are passed to it'
+    it "should exclude any passed models that aren't taggable"
+    it 'should not generate any seeds if none of the passed models are taggable'
+  end
+
   describe '.seed_order' do
     before do
       # reference the models so they are loaded and added to the RecordTags's seed order tree

--- a/spec/dummy/spec/models/record_tag_spec.rb
+++ b/spec/dummy/spec/models/record_tag_spec.rb
@@ -532,7 +532,13 @@ describe Penman::RecordTag do
 
   describe '.generate_seeds_for_models' do
     it 'should only generate seeds for the models that are passed to it'
-    it "should exclude any passed models that aren't taggable"
+
+    it "should exclude any passed models that aren't taggable" do
+      PlayerInfo.create!(player_id: 1, key: 'asdf', value: 'asdf')
+      seed_files = Penman::RecordTag.generate_seeds_for_models([PlayerInfo])
+      expect(seed_files).to be_empty
+    end
+
     it 'should not generate any seeds if none of the passed models are taggable'
   end
 

--- a/spec/dummy/spec/models/record_tag_spec.rb
+++ b/spec/dummy/spec/models/record_tag_spec.rb
@@ -533,7 +533,13 @@ describe Penman::RecordTag do
   describe '.generate_seeds_for_models' do
     before { PlayerInfo.create!(player_id: 1, key: 'asdf', value: 'asdf') }
 
-    it 'should only generate seeds for the models that are passed to it'
+    it 'should only generate seeds for the models that are passed to it' do
+      Item.create!(reference: 'asdf', asset: Asset.first)
+      Player.create!(name: 'asdf')
+      seed_files = Penman::RecordTag.generate_seeds_for_models([Item])
+      expect(seed_files.count).to eq 1
+      expect(seed_files.first.split('/').last).to match(/\d{14}_items_updates.rb/)
+    end
 
     it "should exclude any passed models that aren't taggable" do
       seed_files = Penman::RecordTag.generate_seeds_for_models([PlayerInfo])

--- a/spec/dummy/spec/models/record_tag_spec.rb
+++ b/spec/dummy/spec/models/record_tag_spec.rb
@@ -531,15 +531,20 @@ describe Penman::RecordTag do
   end
 
   describe '.generate_seeds_for_models' do
+    before { PlayerInfo.create!(player_id: 1, key: 'asdf', value: 'asdf') }
+
     it 'should only generate seeds for the models that are passed to it'
 
     it "should exclude any passed models that aren't taggable" do
-      PlayerInfo.create!(player_id: 1, key: 'asdf', value: 'asdf')
       seed_files = Penman::RecordTag.generate_seeds_for_models([PlayerInfo])
       expect(seed_files).to be_empty
     end
 
-    it 'should not generate any seeds if none of the passed models are taggable'
+    it 'should not generate any seeds if none of the passed models are taggable' do
+      expect(Penman::RecordTag).to_not receive(:generate_update_seed)
+      expect(Penman::RecordTag).to_not receive(:generate_destroy_seed)
+      Penman::RecordTag.generate_seeds_for_models([PlayerInfo])
+    end
   end
 
   describe '.seed_order' do


### PR DESCRIPTION
## Changes
* Pluralize `generate_seed_for_models` to align with `generate_seeds`
* Expose that method, `generate_seeds_for_models` as a public API method.
* Have the private method perform the model validation/ordering based on provided models (using helper to diff w/ taggable_models and order w/ seed_order)
* Update seed_order to take models param instead of grabbing models directly from class.