### PR TITLE
Bypass any default scoping for :deleted_at

### DIFF
--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -5,7 +5,8 @@ require 'penman/seed_code'
 
 module Penman
   class RecordTag < ActiveRecord::Base
-    belongs_to :record, polymorphic: true
+    # We unscope to bypass default scope for 'soft-deleted' records.
+    belongs_to :record, -> { unscope(where: :deleted_at) }, polymorphic: true
     validates_uniqueness_of :tag, scope: [:record_type, :record_id]
 
     before_save :encode_candidate_key


### PR DESCRIPTION
## Changes

Cloud Breakers recently started using `paranoia` for soft-deleting records on our "reference" data models.

As a result, we sometimes have RecordTag tuples pointing at soft deleted records. Since `paranoia` sets default scope on a model, it means that these lookups in Penman will fail (`belongs_to` returns nil), which causes an issue (at the earliest) when we call `validate!` on the record.

This change "undoes" any default scoping on a `deleted_at` column. It should work safely with tables that lack this column.
