### PR TITLE
Handle file name generation for classes in modules

### DIFF
--- a/lib/penman/record_tag.rb
+++ b/lib/penman/record_tag.rb
@@ -223,7 +223,8 @@ module Penman
         end
 
         seed_code << 'Penman.enable if penman_initially_enabled'
-        seed_file_name = Penman.config.file_name_formatter.call(model.name, 'updates')
+        model_name = model.name.tr('/', '_')
+        seed_file_name = Penman.config.file_name_formatter.call(model_name, 'updates')
         sfg = SeedFileGenerator.new(seed_file_name, timestamp, seed_code)
         sfg.write_seed
       end


### PR DESCRIPTION
Currently if you generate seeds for a class that's in a module Penman will accidentally try to nest them in a directory within seeds. For example seeds for the class `Ingot::Choices` will end up in the directory `db/seeds/20161111111425_ingot/choices_updates.rb`. This is because `.name` puts slashes after modules. By converting slashes to underscores in the models name we'll end up with `db/seeds/20161111111425_ingot_choices_updates.rb` instead.

